### PR TITLE
chore(deps): allow both `v5` and `v6` of nest.js as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "^3.3.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "^5.1.0"
+    "@nestjs/common": "^5.1.0 || ^6.0.3"
   },
   "dependencies": {
     "amqplib": "^0.5.2",


### PR DESCRIPTION
Allows to use package in `nest@v5` and in `nest@v6`

You can verify version range here:
https://jubianchi.github.io/semver-check/#/^5.1.0%20||%20^6.0.3/5.1.1